### PR TITLE
aligned golang major version with Dockerfile

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: golang:1.14
+image: golang:1.15
 
 before_script:
   - export DOCKER_REPOSITORY="mendersoftware/mender-stress-test-client"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mendersoftware/mender-stress-test-client
 
-go 1.14
+go 1.15
 
 require (
 	github.com/bmatsuo/lmdb-go v1.8.0 // indirect


### PR DESCRIPTION
just since I saw the dependabot PR earlier... should we do this everywhere? especially with regards to the `go.mod` file... or is it ok to leave it at some version?

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>