### PR TITLE
based binary build on non-alpine to ease using the binary in non-musl surroundings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM golang:1.16.2-alpine3.12 as builder
-RUN apk add --no-cache gcc musl-dev openssl-dev
+FROM golang:1.16.2 as builder
+RUN apt-get update -qqy && apt-get install -qqy gcc libssl-dev
 RUN mkdir -p /go/src/github.com/mendersoftware/mender-stress-test-client
 WORKDIR /go/src/github.com/mendersoftware/mender-stress-test-client
 ADD ./ .
@@ -7,5 +7,5 @@ RUN go build
 
 FROM alpine:3.13.2
 COPY --from=builder /go/src/github.com/mendersoftware/mender-stress-test-client/mender-stress-test-client /
-RUN apk add --no-cache ca-certificates && update-ca-certificates
+RUN apk add --no-cache ca-certificates libc6-compat && update-ca-certificates
 ENTRYPOINT ["/mender-stress-test-client"]


### PR DESCRIPTION
while this results in slightly longer build times (due to the time it takes to load the full golang image), the change in image size is negligible IMHO... due to the lmdb dependency I failed to get a cross compilation going - thus the slightly easier approach...
this is basically in use in https://github.com/mendersoftware/gui/pull/1418 as the e2e tests run the extracted binary in a `debian:buster` based image...



Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>