### PR TITLE
If skip verify is set , then we shouldnt call VerifyResult

### DIFF
--- a/vendor/github.com/mendersoftware/mender/client/client.go
+++ b/vendor/github.com/mendersoftware/mender/client/client.go
@@ -464,6 +464,10 @@ func dialOpenSSL(ctx *openssl.Ctx, conf *Config, network string, addr string) (n
 		return nil, err
 	}
 
+	if conf.NoVerify {
+		return conn, nil
+	}
+
 	v := conn.VerifyResult()
 	if v != openssl.Ok {
 		if v == openssl.CertHasExpired {


### PR DESCRIPTION
Changelog: Commit
Signed-off-by: Prashanth Joseph Babu <prashanthjbabu@gmail.com>

Same fix as https://github.com/mendersoftware/mender/pull/744