### PR TITLE
Use `req.Close = true` when using golang http client's NewRequest in parallel(goroutine)

### DIFF
--- a/vendor/github.com/mendersoftware/mender/client/client.go
+++ b/vendor/github.com/mendersoftware/mender/client/client.go
@@ -238,7 +238,7 @@ func (ar *ApiRequest) Do(req *http.Request) (*http.Response, error) {
 		newReq, _ := http.NewRequest(req.Method, req.URL.String(), body)
 		newReq.Header = req.Header
 		newReq.GetBody = req.GetBody
-
+		newReq.Close = true
 		r, err = ar.tryDo(newReq, server.ServerURL)
 		if err == nil && r.StatusCode < 400 {
 			break

--- a/vendor/github.com/mendersoftware/mender/client/client_auth.go
+++ b/vendor/github.com/mendersoftware/mender/client/client_auth.go
@@ -123,7 +123,7 @@ func makeAuthRequest(server string, dataSrc AuthDataMessenger) (*http.Request, e
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create authorization HTTP request")
 	}
-
+	hreq.Close = true
 	hreq.Header.Add("Content-Type", "application/json")
 	hreq.Header.Add("Authorization", fmt.Sprintf("Bearer %s", req.Token))
 	hreq.Header.Add("X-MEN-Signature", base64.StdEncoding.EncodeToString(req.Signature))

--- a/vendor/github.com/mendersoftware/mender/client/client_inventory.go
+++ b/vendor/github.com/mendersoftware/mender/client/client_inventory.go
@@ -85,7 +85,7 @@ func makeInventorySubmitRequest(method, server string, data interface{}) (*http.
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create inventory HTTP request")
 	}
-
+	hreq.Close = true
 	hreq.Header.Add("Content-Type", "application/json")
 	return hreq, nil
 }

--- a/vendor/github.com/mendersoftware/mender/client/client_log.go
+++ b/vendor/github.com/mendersoftware/mender/client/client_log.go
@@ -72,7 +72,7 @@ func makeLogUploadRequest(server string, logs *LogData) (*http.Request, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create log sending HTTP request")
 	}
-
+	hreq.Close = true
 	hreq.Header.Add("Content-Type", "application/json")
 	return hreq, nil
 }

--- a/vendor/github.com/mendersoftware/mender/client/client_status.go
+++ b/vendor/github.com/mendersoftware/mender/client/client_status.go
@@ -108,7 +108,7 @@ func makeStatusReportRequest(server string, report StatusReport) (*http.Request,
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create status HTTP request")
 	}
-
+	hreq.Close = true
 	hreq.Header.Add("Content-Type", "application/json")
 	return hreq, nil
 }

--- a/vendor/github.com/mendersoftware/mender/client/client_update.go
+++ b/vendor/github.com/mendersoftware/mender/client/client_update.go
@@ -241,7 +241,7 @@ func makeUpdateCheckRequest(server string, current *CurrentUpdate) (*http.Reques
 	if err != nil {
 		return nil, nil, err
 	}
-
+	postReq.Close = true
 	postReq.Header.Add("Content-Type", "application/json")
 
 	if len(vals) != 0 {
@@ -252,6 +252,7 @@ func makeUpdateCheckRequest(server string, current *CurrentUpdate) (*http.Reques
 	if err != nil {
 		return nil, nil, err
 	}
+	getReq.Close = true
 	return postReq, getReq, nil
 }
 
@@ -260,5 +261,6 @@ func makeUpdateFetchRequest(url string) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
+	req.Close = true
 	return req, nil
 }

--- a/vendor/github.com/stretchr/testify/assert/http_assertions.go
+++ b/vendor/github.com/stretchr/testify/assert/http_assertions.go
@@ -16,6 +16,7 @@ func httpCode(handler http.HandlerFunc, method, url string, values url.Values) (
 	if err != nil {
 		return -1, err
 	}
+	req.Close = true
 	req.URL.RawQuery = values.Encode()
 	handler(w, req)
 	return w.Code, nil
@@ -117,6 +118,7 @@ func HTTPBody(handler http.HandlerFunc, method, url string, values url.Values) s
 	if err != nil {
 		return ""
 	}
+	req.Close = true
 	handler(w, req)
 	return w.Body.String()
 }


### PR DESCRIPTION
When running mender-stress-client for over 1000 clients , we sometimes get an `EOF` error from the http client library.
There are quite a few references on the internet which quote this problem : 
https://stackoverflow.com/questions/28046100/golang-http-concurrent-requests-post-eof
https://stackoverflow.com/questions/17714494/golang-http-request-results-in-eof-errors-when-making-multiple-requests-successi/23963271#23963271
https://stackoverflow.com/questions/28046100/golang-http-concurrent-requests-post-eof#34474535
https://stackoverflow.com/questions/28046100/golang-http-concurrent-requests-post-eof#34474535

The solution is to use `req.Close = true` when using golang http client's NewRequest in parallel(goroutine) . This ensures that the connection isnt reused and the EOF error would not occur.


Changelog: Commit
Signed-off-by: Prashanth Joseph Babu <prashanthjbabu@gmail.com>