### PR TITLE
ci: Use shared template for linting

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,13 +24,3 @@ include:
     file: '.gitlab-ci-github-status-updates.yml'
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-docker-build.yml'
-
-test:static:
-  image: golang:1.16
-  needs: []
-  before_script:
-    - |
-      curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
-           sh -s -- -b $(go env GOPATH)/bin v1.31.0
-  script:
-    - golangci-lint run -v

--- a/websocket/connection.go
+++ b/websocket/connection.go
@@ -53,7 +53,7 @@ type Connection struct {
 	done chan bool
 }
 
-//Websocket connection routine. setup the ping-pong and connection settings
+// Websocket connection routine. setup the ping-pong and connection settings
 func NewConnection(serverURL string, token string) (*Connection, error) {
 	wsServerURL := "ws" + strings.TrimRight(serverURL[4:], "/")
 	parsedURL, err := url.Parse(wsServerURL + defaultDeviceConnectPath)


### PR DESCRIPTION
Golang 1.16 is quite dated already. It is unknown why it was decided to override the script for this particular repository.