### PR TITLE
chore: update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,23 +6,21 @@ updates:
     package-ecosystem: gomod
     schedule:
       interval: monthly
-      day: saturday
     groups:
       golang-dependencies:
         patterns:
           - "*"
     reviewers:
-      - "mendersoftware/qa-dependabot-reviewers"
+      - "mendersoftware/backend-dependabot-reviewers"
   - commit-message:
       prefix: chore
     directory: /
     package-ecosystem: docker
     schedule:
       interval: monthly
-      day: saturday
     groups:
       docker-dependencies:
         patterns:
           - "*"
     reviewers:
-      - "mendersoftware/qa-dependabot-reviewers"
+      - "mendersoftware/backend-dependabot-reviewers"


### PR DESCRIPTION
Change reviewers from QA team to the backend team, which effectively means that from now on the backend team will be responsible for updating dependencies in this repository.