### PR TITLE
ci: add qa-common retry and runner defaults

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,10 @@ stages:
   - publish
 
 include:
+  - project: Northern.tech/Mender/mendertesting
+    file:
+      - qa-common/runner.yml
+      - qa-common/retry.yml
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-golang-lint.yml'
   - project: 'Northern.tech/Mender/mendertesting'
@@ -24,3 +28,7 @@ include:
     file: '.gitlab-ci-github-status-updates.yml'
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-docker-build.yml'
+
+default:
+  tags: !reference [.qa-common-default-runner, tags]
+  retry: !reference [.qa-common-default-retry, retry]


### PR DESCRIPTION
Include qa-common/runner.yml and qa-common/retry.yml from mendertesting to apply a consistent .qa-common-default-runner tag and .qa-common-default-retry policy to all jobs pipeline-wide.

Add network probes (apt/go/git-clone) to jobs that perform network operations, so transient failures trigger a retry instead of a hard fail.

Ticket: QA-1490